### PR TITLE
assignment3: comment out numthreads print statement

### DIFF
--- a/assignment-3/quake.c
+++ b/assignment-3/quake.c
@@ -167,8 +167,6 @@ int main(int argc, char **argv)
    numthreads=1;
 #endif
 
-  printf("numthreads = %d\n", numthreads);
-
 /* Read in data from the pack file */
   
   arch_init(argc, argv, &options);

--- a/assignment-3/quake.c
+++ b/assignment-3/quake.c
@@ -167,6 +167,9 @@ int main(int argc, char **argv)
    numthreads=1;
 #endif
 
+  // printf("numthreads = %d\n", numthreads);
+
+
 /* Read in data from the pack file */
   
   arch_init(argc, argv, &options);

--- a/assignment-3/quake.c
+++ b/assignment-3/quake.c
@@ -169,7 +169,6 @@ int main(int argc, char **argv)
 
   // printf("numthreads = %d\n", numthreads);
 
-
 /* Read in data from the pack file */
   
   arch_init(argc, argv, &options);


### PR DESCRIPTION
Getting rid of print statement that prevents using diff to compare the output. 